### PR TITLE
fix: 修正聊天室紅點邏輯錯誤 

### DIFF
--- a/rtchat/views.py
+++ b/rtchat/views.py
@@ -98,6 +98,8 @@ def unread_message_count(request):
             group__members=request.user
         ).exclude(
             read_statuses__user=request.user
+        ).exclude(
+            author=request.user
         ).count()
         return JsonResponse({'unread_count': unread})
     return JsonResponse({'unread_count': 0})
@@ -111,6 +113,8 @@ def unread_message_badge(request):
             group__members=request.user
         ).exclude(
             read_statuses__user=request.user
+        ).exclude(
+            author=request.user
         ).count()
     else:
         unread_count = 0
@@ -126,6 +130,7 @@ def unread_chatroom_status(request):
         GroupMessage.objects
         .filter(group__in=chatgroups)
         .exclude(read_statuses__user=user)
+        .exclude(author=user)
         .values_list("group_id", flat=True)
         .distinct()
     )


### PR DESCRIPTION
##  變更內容  
- 修改未讀訊息邏輯，排除自己傳送的訊息  
- 調整 message icon 與聊天室列表紅點邏輯  

##  測試方式  
1️⃣ 需切換帳號測試
2️⃣ A傳訊息 →  B
3️⃣ (看下方gif) 切換至 B 帳號，navbar 的 message icon 看到紅點及未讀訊息數，點進 A 聊天室後紅點消失

![message _dot_github_pr](https://github.com/user-attachments/assets/d6fc4268-be38-4ae3-8b86-ede4239610cc)


## 關聯 Issue  
Closes #3 
